### PR TITLE
Fix unbind

### DIFF
--- a/src/abt.ml
+++ b/src/abt.ml
@@ -113,7 +113,7 @@ struct
   let unbind (tm : t) : Variable.t * t =
     let v = Variable.fresh "x" in
     let free n v' = if Variable.equal v v' then raise Malformed else Free v' in
-    let bound _ m = if m = 0 then Free v else Bound m in
+    let bound n m = if n = m then Free v else Bound m in
     (v, map_variables free bound tm)
 
   let into = function


### PR DESCRIPTION
unbind converts `Lambda t` to `L v t'` with variable bound to `v` becoming free variable. For the current implementation, only the top level bound variables are changed to free variables while Variables in lower level are not changed.

For example:

Lambda Term :

`Lambda (Plus (Bound 0) (Lambda (id (Bound 1))))`

Should be un-bound to view

`L x (Plus x (L (id x)))`

Instead of 
`L x (Plus x (L (id (Bound 1))))`
